### PR TITLE
fix mainVersion in deployment-tool

### DIFF
--- a/release.py
+++ b/release.py
@@ -315,8 +315,8 @@ def do_deployment_tool(dir_path, version):
         repos
     )
     repos = re.sub(
-        'mainVersion:\s*[^,]+,\n',
-        'mainVersion: \''+ version + '\',\n',
+        'mainVersion:\s*[^,]+\n',
+        'mainVersion: \''+ version + '\'\n',
         repos
     )
     write_text_file(os.path.join(dir_path, "config.yml"), repos)


### PR DESCRIPTION
mainVersion was not being set correctly in the release process within `deployment-tool/config.yml` file.