### PR TITLE
Adding support for updating dependabot branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "master"
+    # Disable version updates for npm dependencies, only enabling security
+    # updates. See 
+    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "6.1.x"
+    # Disable version updates for npm dependencies, only enabling security
+    # updates. See 
+    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+    open-pull-requests-limit: 0
+

--- a/.github/dependabot.yml.tpl
+++ b/.github/dependabot.yml.tpl
@@ -1,0 +1,14 @@
+version: 2
+updates:
+{% for branch in branches %}
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "{{ branch }}"
+    # Disable version updates for npm dependencies, only enabling security
+    # updates. See 
+    # https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+    open-pull-requests-limit: 0
+
+{% endfor %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 certifi==2021.10.8
 charset-normalizer==2.0.7
 idna==3.3
+Jinja2==3.1.2
+MarkupSafe==2.1.1
 requests==2.26.0
 urllib3==1.26.7


### PR DESCRIPTION
Adds support for the `--set-dependabot-branches` option, that will update the `.github/dependabot.yml` file using the listed branches and the `.github/dependabot.yml.tpl` template.

This is useful to set the branches in which security issues should be reported, for example.